### PR TITLE
performance improvement for DFA-based engine

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -28,6 +28,18 @@ fn dfa_2(c: &mut criterion::Criterion) {
     });
 }
 
+fn dfa_long(c: &mut criterion::Criterion) {
+    let target_regex = "a+b";
+
+    let regex = rustegex::RustRegex::new(target_regex, "dfa").unwrap();
+
+    c.bench_function("DFA long", |b| {
+        b.iter(|| {
+            regex.is_match("a".repeat(1000000).as_str());
+        })
+    });
+}
+
 fn vm_1(c: &mut criterion::Criterion) {
     let target_regex = "(p(erl|ython|hp)|ruby)";
     let targets = vec!["perl", "python", "ruby", "rust"];
@@ -92,6 +104,7 @@ criterion::criterion_group!(
     benches,
     dfa_1,
     dfa_2,
+    dfa_long,
     vm_1,
     vm_2,
     derivative_1,

--- a/src/automaton/nfa.rs
+++ b/src/automaton/nfa.rs
@@ -175,9 +175,9 @@ impl Nfa {
 
     pub fn epsilon_closure(
         &self,
-        start: std::collections::BTreeSet<crate::automaton::nfa::NfaStateID>,
-    ) -> std::collections::BTreeSet<crate::automaton::nfa::NfaStateID> {
-        let mut visited = std::collections::BTreeSet::new();
+        start: std::collections::BTreeSet<NfaStateID>,
+    ) -> std::collections::BTreeSet<NfaStateID> {
+        let mut visited = std::collections::HashSet::new();
         let mut to_visit = std::collections::VecDeque::new();
 
         for &state in start.iter() {
@@ -187,19 +187,16 @@ impl Nfa {
         }
 
         while let Some(state) = to_visit.pop_front() {
-            if visited.contains(&state) {
-                continue;
-            }
-            visited.insert(state);
-
-            for &(from, label, to) in self.transitions() {
-                if from == state && label.is_none() && !visited.contains(&to) {
-                    to_visit.push_back(to);
+            if visited.insert(state) {
+                for &(from, label, to) in self.transitions() {
+                    if from == state && label.is_none() && !visited.contains(&to) {
+                        to_visit.push_back(to);
+                    }
                 }
             }
         }
 
-        visited
+        visited.into_iter().collect()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,9 @@ impl RustRegex {
             Regex::Vm { vm } => vm.is_match(input),
             Regex::Derivative { derivative } => {
                 if input.is_empty() {
-                    derivative.is_empty_match()
-                } else {
-                    derivative.is_match(input)
+                    return derivative.is_empty_match();
                 }
+                derivative.is_match(input)
             }
         }
     }


### PR DESCRIPTION
Reduced matching time mainly by rewriting the processing of the `epsilon_closure` method:
![performance improved](https://github.com/user-attachments/assets/4f101d55-df2c-475f-99e3-81c141755a64)
