### PR TITLE
use cache in DFA for long input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ impl RustRegex {
         if method == "dfa" {
             let nfa =
                 automaton::nfa::Nfa::new_from_node(ast, &mut automaton::nfa::NfaState::new())?;
-            let dfa = automaton::dfa::Dfa::from_nfa(&nfa);
+            let dfa = automaton::dfa::Dfa::from_nfa(&nfa, use_dfa_cache(input));
 
             Ok(RustRegex {
                 regex: Regex::Dfa { dfa },
@@ -62,6 +62,10 @@ impl RustRegex {
             }
         }
     }
+}
+
+pub fn use_dfa_cache(input: &str) -> bool {
+    input.len() > 1000
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the DFA-based engine for inputs with long lengths, the node ID in the DFA that should be transitioned to next can be cached by using the pair of the node ID currently watching and the input character as a key to improve the efficiency of the transition destination search:
![improved_dfa_long](https://github.com/user-attachments/assets/b528b274-8763-4cce-9b61-d06d7974d15c)
