### PR TITLE
Replace enum-based VM instruction representation with SoA

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -4,7 +4,7 @@ mod instruction;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Vm {
-    bytecode: Vec<instruction::Instruction>,
+    bytecode: instruction::Program,
 }
 
 impl Vm {
@@ -13,7 +13,7 @@ impl Vm {
         compiler.compile(ast)?;
 
         Ok(Vm {
-            bytecode: compiler.instructions().to_vec(),
+            bytecode: compiler.finish(),
         })
     }
 

--- a/src/vm/compile.rs
+++ b/src/vm/compile.rs
@@ -1,101 +1,57 @@
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Compiler {
-    pc: usize,
-    instructions: Vec<crate::vm::instruction::Instruction>,
+    builder: crate::vm::instruction::ProgramBuilder,
 }
 
 impl Compiler {
     pub fn new() -> Self {
         Compiler {
-            pc: 0,
-            instructions: Vec::new(),
+            builder: crate::vm::instruction::ProgramBuilder::new(),
         }
     }
 
-    pub fn instructions(&self) -> &Vec<crate::vm::instruction::Instruction> {
-        &self.instructions
-    }
-
-    fn emit(&mut self, instruction: crate::vm::instruction::Instruction) {
-        self.instructions.push(instruction);
-        self.pc += 1;
-    }
-
-    fn patch(&mut self, pc: usize, instruction: crate::vm::instruction::Instruction) {
-        self.instructions[pc] = instruction;
+    pub fn finish(self) -> crate::vm::instruction::Program {
+        self.builder.build()
     }
 
     fn _compile(&mut self, ast: crate::parser::AstNode) -> crate::Result<()> {
         match ast {
             crate::parser::AstNode::Char(c) => {
-                self.emit(crate::vm::instruction::Instruction::Char(c));
+                self.builder.emit_char(c);
             }
             crate::parser::AstNode::Plus(node) => {
-                let split = self.pc;
-                self.emit(crate::vm::instruction::Instruction::Split(0, 0));
-                let start = self.pc;
+                let split = self.builder.reserve_split();
+                let start = self.builder.pc();
                 self._compile(*node)?;
-                self.emit(crate::vm::instruction::Instruction::Jmp(split));
-                let end = self.pc;
-                self.patch(
-                    split,
-                    crate::vm::instruction::Instruction::Split(start, end),
-                );
+                self.builder.emit_jmp(split);
+                let end = self.builder.pc();
+                self.builder.patch_split(split, start, end);
             }
             crate::parser::AstNode::Star(node) => {
-                let split = self.pc;
-                self.pc += 1;
-                self.instructions
-                    .push(crate::vm::instruction::Instruction::Split(self.pc, 0));
+                let split = self.builder.pc();
+                let body_start = split + 1;
+                self.builder.emit_split(body_start, 0);
                 self._compile(*node)?;
-                self.pc += 1;
-                self.instructions
-                    .push(crate::vm::instruction::Instruction::Jmp(split));
-
-                if let Some(crate::vm::instruction::Instruction::Split(_, expr)) =
-                    self.instructions.get_mut(split)
-                {
-                    *expr = self.pc;
-                } else {
-                    return Err(crate::error::Error::CompileError);
-                }
+                self.builder.emit_jmp(split);
+                let end = self.builder.pc();
+                self.builder.patch_split_second(split, end);
             }
             crate::parser::AstNode::Question(node) => {
-                let split = self.pc;
-                self.emit(crate::vm::instruction::Instruction::Split(0, 0));
-                let start = self.pc;
+                let split = self.builder.reserve_split();
+                let start = self.builder.pc();
                 self._compile(*node)?;
-                let end = self.pc;
-                self.patch(
-                    split,
-                    crate::vm::instruction::Instruction::Split(start, end),
-                );
+                let end = self.builder.pc();
+                self.builder.patch_split(split, start, end);
             }
             crate::parser::AstNode::Or(left, right) => {
-                let split = self.pc;
-                self.pc += 1;
-                self.instructions
-                    .push(crate::vm::instruction::Instruction::Split(self.pc, 0));
+                let split = self.builder.reserve_split();
+                let start = self.builder.pc();
                 self._compile(*left)?;
-                let jump = self.pc;
-                self.emit(crate::vm::instruction::Instruction::Jmp(0));
-
-                if let Some(crate::vm::instruction::Instruction::Split(_, expr)) =
-                    self.instructions.get_mut(split)
-                {
-                    *expr = self.pc;
-                } else {
-                    return Err(crate::error::Error::CompileError);
-                }
-
+                let jump = self.builder.reserve_jmp();
+                let right_start = self.builder.pc();
+                self.builder.patch_split_second(split, right_start);
                 self._compile(*right)?;
-                if let Some(crate::vm::instruction::Instruction::Jmp(expr)) =
-                    self.instructions.get_mut(jump)
-                {
-                    *expr = self.pc;
-                } else {
-                    return Err(crate::error::Error::CompileError);
-                }
+                self.builder.patch_jmp(jump, self.builder.pc());
+                self.builder.patch_split(split, start, right_start);
             }
             crate::parser::AstNode::Seq(left, right) => {
                 if let (crate::parser::AstNode::Epsilon, crate::parser::AstNode::Epsilon) =
@@ -115,10 +71,7 @@ impl Compiler {
 
     pub fn compile(&mut self, ast: crate::parser::AstNode) -> crate::Result<()> {
         self._compile(ast)?;
-        self.pc += 1;
-        self.instructions
-            .push(crate::vm::instruction::Instruction::Match);
-
+        self.builder.emit_match();
         Ok(())
     }
 }
@@ -127,60 +80,63 @@ impl Compiler {
 mod tests {
     use super::*;
 
+    fn compile_pattern(pattern: &str) -> crate::vm::instruction::Program {
+        let mut lexer = crate::lexer::Lexer::new(pattern);
+        let mut parser = crate::parser::Parser::new(&mut lexer);
+        let ast = parser.parse().unwrap();
+        let mut compiler = Compiler::new();
+        compiler.compile(ast).unwrap();
+        compiler.finish()
+    }
+
+    fn assert_program(program: &crate::vm::instruction::Program, expected: &[(u8, u32, u32)]) {
+        assert_eq!(program.len(), expected.len());
+        for (pc, &(opcode, op1, op2)) in expected.iter().enumerate() {
+            assert_eq!(program.opcode(pc), opcode, "opcode mismatch at pc {pc}");
+            assert_eq!(program.operand1(pc), op1, "op1 mismatch at pc {pc}");
+            assert_eq!(program.operand2(pc), op2, "op2 mismatch at pc {pc}");
+        }
+    }
+
     #[test]
     fn compile() {
-        let mut lexer = crate::lexer::Lexer::new("a|b");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = Compiler::new();
-        compiler.compile(ast).unwrap();
-        assert_eq!(
-            compiler.instructions,
-            vec![
-                crate::vm::instruction::Instruction::Split(1, 3),
-                crate::vm::instruction::Instruction::Char('a'),
-                crate::vm::instruction::Instruction::Jmp(4),
-                crate::vm::instruction::Instruction::Char('b'),
-                crate::vm::instruction::Instruction::Match,
-            ]
+        assert_program(
+            &compile_pattern("a|b"),
+            &[
+                (crate::vm::instruction::OP_SPLIT, 1, 3),
+                (crate::vm::instruction::OP_CHAR, 'a' as u32, 0),
+                (crate::vm::instruction::OP_JMP, 4, 0),
+                (crate::vm::instruction::OP_CHAR, 'b' as u32, 0),
+                (crate::vm::instruction::OP_MATCH, 0, 0),
+            ],
         );
 
-        let mut lexer = crate::lexer::Lexer::new("aa*bb*");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = Compiler::new();
-        compiler.compile(ast).unwrap();
-        assert_eq!(
-            compiler.instructions,
-            vec![
-                crate::vm::instruction::Instruction::Char('a'),
-                crate::vm::instruction::Instruction::Split(2, 4),
-                crate::vm::instruction::Instruction::Char('a'),
-                crate::vm::instruction::Instruction::Jmp(1),
-                crate::vm::instruction::Instruction::Char('b'),
-                crate::vm::instruction::Instruction::Split(6, 8),
-                crate::vm::instruction::Instruction::Char('b'),
-                crate::vm::instruction::Instruction::Jmp(5),
-                crate::vm::instruction::Instruction::Match,
-            ]
+        assert_program(
+            &compile_pattern("aa*bb*"),
+            &[
+                (crate::vm::instruction::OP_CHAR, 'a' as u32, 0),
+                (crate::vm::instruction::OP_SPLIT, 2, 4),
+                (crate::vm::instruction::OP_CHAR, 'a' as u32, 0),
+                (crate::vm::instruction::OP_JMP, 1, 0),
+                (crate::vm::instruction::OP_CHAR, 'b' as u32, 0),
+                (crate::vm::instruction::OP_SPLIT, 6, 8),
+                (crate::vm::instruction::OP_CHAR, 'b' as u32, 0),
+                (crate::vm::instruction::OP_JMP, 5, 0),
+                (crate::vm::instruction::OP_MATCH, 0, 0),
+            ],
         );
 
-        let mut lexer = crate::lexer::Lexer::new("a|b*");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = Compiler::new();
-        compiler.compile(ast).unwrap();
-        assert_eq!(
-            compiler.instructions,
-            vec![
-                crate::vm::instruction::Instruction::Split(1, 3),
-                crate::vm::instruction::Instruction::Char('a'),
-                crate::vm::instruction::Instruction::Jmp(6),
-                crate::vm::instruction::Instruction::Split(4, 6),
-                crate::vm::instruction::Instruction::Char('b'),
-                crate::vm::instruction::Instruction::Jmp(3),
-                crate::vm::instruction::Instruction::Match,
-            ]
+        assert_program(
+            &compile_pattern("a|b*"),
+            &[
+                (crate::vm::instruction::OP_SPLIT, 1, 3),
+                (crate::vm::instruction::OP_CHAR, 'a' as u32, 0),
+                (crate::vm::instruction::OP_JMP, 6, 0),
+                (crate::vm::instruction::OP_SPLIT, 4, 6),
+                (crate::vm::instruction::OP_CHAR, 'b' as u32, 0),
+                (crate::vm::instruction::OP_JMP, 3, 0),
+                (crate::vm::instruction::OP_MATCH, 0, 0),
+            ],
         );
     }
 }

--- a/src/vm/eval.rs
+++ b/src/vm/eval.rs
@@ -1,4 +1,4 @@
-fn add_state_mask(inst: &[crate::vm::instruction::Instruction], pc: usize, mask: &mut u64) {
+fn add_state_mask(inst: &crate::vm::instruction::Program, pc: usize, mask: &mut u64) {
     if pc >= inst.len() {
         return;
     }
@@ -8,12 +8,15 @@ fn add_state_mask(inst: &[crate::vm::instruction::Instruction], pc: usize, mask:
     }
     *mask |= bit;
 
-    match inst[pc] {
-        crate::vm::instruction::Instruction::Split(x, y) => {
+    match inst.opcode(pc) {
+        crate::vm::instruction::OP_SPLIT => {
+            let x = inst.operand1(pc) as usize;
+            let y = inst.operand2(pc) as usize;
             add_state_mask(inst, x, mask);
             add_state_mask(inst, y, mask);
         }
-        crate::vm::instruction::Instruction::Jmp(x) => {
+        crate::vm::instruction::OP_JMP => {
+            let x = inst.operand1(pc) as usize;
             add_state_mask(inst, x, mask);
         }
         _ => {}
@@ -24,28 +27,27 @@ fn for_each_set_bit(mut mask: u64, mut f: impl FnMut(usize)) {
     while mask != 0 {
         let pc = mask.trailing_zeros() as usize;
         f(pc);
-        mask &= mask - 1; // clear lowest set bit
+        mask &= mask - 1;
     }
 }
 
 #[inline(never)]
-fn pike_eval_bitmask(inst: &[crate::vm::instruction::Instruction], input: &str) -> bool {
+fn pike_eval_bitmask(inst: &crate::vm::instruction::Program, input: &str) -> bool {
     let mut current: u64 = 0;
     add_state_mask(inst, 0, &mut current);
 
     if input.is_ascii() {
-        // ascii fast path
         for &byte in input.as_bytes() {
             if current == 0 {
                 return false;
             }
             let mut next: u64 = 0;
             for_each_set_bit(current, |pc| {
-                if let crate::vm::instruction::Instruction::Char(expected) = inst[pc]
-                    && expected as u32 <= 127
-                    && expected as u8 == byte
-                {
-                    add_state_mask(inst, pc + 1, &mut next);
+                if inst.opcode(pc) == crate::vm::instruction::OP_CHAR {
+                    let expected = inst.operand1(pc);
+                    if expected <= 127 && expected as u8 == byte {
+                        add_state_mask(inst, pc + 1, &mut next);
+                    }
                 }
             });
             current = next;
@@ -57,10 +59,11 @@ fn pike_eval_bitmask(inst: &[crate::vm::instruction::Instruction], input: &str) 
             }
             let mut next: u64 = 0;
             for_each_set_bit(current, |pc| {
-                if let crate::vm::instruction::Instruction::Char(expected) = inst[pc]
-                    && expected == ch
-                {
-                    add_state_mask(inst, pc + 1, &mut next);
+                if inst.opcode(pc) == crate::vm::instruction::OP_CHAR {
+                    let expected = inst.char_literal(pc);
+                    if expected == ch {
+                        add_state_mask(inst, pc + 1, &mut next);
+                    }
                 }
             });
             current = next;
@@ -69,7 +72,7 @@ fn pike_eval_bitmask(inst: &[crate::vm::instruction::Instruction], input: &str) 
 
     let mut found = false;
     for_each_set_bit(current, |pc| {
-        if matches!(inst[pc], crate::vm::instruction::Instruction::Match) {
+        if inst.opcode(pc) == crate::vm::instruction::OP_MATCH {
             found = true;
         }
     });
@@ -77,7 +80,7 @@ fn pike_eval_bitmask(inst: &[crate::vm::instruction::Instruction], input: &str) 
 }
 
 fn add_state_vec(
-    inst: &[crate::vm::instruction::Instruction],
+    inst: &crate::vm::instruction::Program,
     pc: usize,
     list: &mut Vec<usize>,
     gen_arr: &mut [u32],
@@ -86,19 +89,21 @@ fn add_state_vec(
     if pc >= inst.len() {
         return;
     }
-    // SAFETY: pc < inst.len() and gen_arr.len() >= inst.len()
     let slot = unsafe { gen_arr.get_unchecked_mut(pc) };
     if *slot == cur_gen {
         return;
     }
     *slot = cur_gen;
 
-    match *unsafe { inst.get_unchecked(pc) } {
-        crate::vm::instruction::Instruction::Split(x, y) => {
+    match inst.opcode(pc) {
+        crate::vm::instruction::OP_SPLIT => {
+            let x = inst.operand1(pc) as usize;
+            let y = inst.operand2(pc) as usize;
             add_state_vec(inst, x, list, gen_arr, cur_gen);
             add_state_vec(inst, y, list, gen_arr, cur_gen);
         }
-        crate::vm::instruction::Instruction::Jmp(x) => {
+        crate::vm::instruction::OP_JMP => {
+            let x = inst.operand1(pc) as usize;
             add_state_vec(inst, x, list, gen_arr, cur_gen);
         }
         _ => {
@@ -147,7 +152,7 @@ thread_local! {
 }
 
 #[inline(never)]
-fn pike_eval_vec(inst: &[crate::vm::instruction::Instruction], input: &str) -> bool {
+fn pike_eval_vec(inst: &crate::vm::instruction::Program, input: &str) -> bool {
     let program_size = inst.len();
 
     BUFFERS.with(|cell| {
@@ -168,12 +173,11 @@ fn pike_eval_vec(inst: &[crate::vm::instruction::Instruction], input: &str) -> b
                 let len = bufs.current.len();
                 for i in 0..len {
                     let pc = *unsafe { bufs.current.get_unchecked(i) };
-                    if let crate::vm::instruction::Instruction::Char(expected) =
-                        *unsafe { inst.get_unchecked(pc) }
-                        && expected as u32 <= 127
-                        && expected as u8 == byte
-                    {
-                        add_state_vec(inst, pc + 1, &mut bufs.next, &mut bufs.gen_arr, g);
+                    if inst.opcode(pc) == crate::vm::instruction::OP_CHAR {
+                        let expected = inst.operand1(pc);
+                        if expected <= 127 && expected as u8 == byte {
+                            add_state_vec(inst, pc + 1, &mut bufs.next, &mut bufs.gen_arr, g);
+                        }
                     }
                 }
                 std::mem::swap(&mut bufs.current, &mut bufs.next);
@@ -188,11 +192,11 @@ fn pike_eval_vec(inst: &[crate::vm::instruction::Instruction], input: &str) -> b
                 let len = bufs.current.len();
                 for i in 0..len {
                     let pc = *unsafe { bufs.current.get_unchecked(i) };
-                    if let crate::vm::instruction::Instruction::Char(expected) =
-                        *unsafe { inst.get_unchecked(pc) }
-                        && expected == ch
-                    {
-                        add_state_vec(inst, pc + 1, &mut bufs.next, &mut bufs.gen_arr, g);
+                    if inst.opcode(pc) == crate::vm::instruction::OP_CHAR {
+                        let expected = inst.char_literal(pc);
+                        if expected == ch {
+                            add_state_vec(inst, pc + 1, &mut bufs.next, &mut bufs.gen_arr, g);
+                        }
                     }
                 }
                 std::mem::swap(&mut bufs.current, &mut bufs.next);
@@ -202,12 +206,12 @@ fn pike_eval_vec(inst: &[crate::vm::instruction::Instruction], input: &str) -> b
 
         bufs.current
             .iter()
-            .any(|&pc| matches!(inst[pc], crate::vm::instruction::Instruction::Match))
+            .any(|&pc| inst.opcode(pc) == crate::vm::instruction::OP_MATCH)
     })
 }
 
 pub fn eval(
-    inst: &[crate::vm::instruction::Instruction],
+    inst: &crate::vm::instruction::Program,
     input: &str,
     _input_looking: usize,
     _pc: usize,
@@ -227,116 +231,72 @@ pub fn eval(
 mod tests {
     use super::*;
 
+    fn compile_and_eval(pattern: &str, input: &str) -> bool {
+        let mut lexer = crate::lexer::Lexer::new(pattern);
+        let mut parser = crate::parser::Parser::new(&mut lexer);
+        let ast = parser.parse().unwrap();
+        let mut compiler = crate::vm::compile::Compiler::new();
+        compiler.compile(ast).unwrap();
+        let inst = compiler.finish();
+        eval(&inst, input, 0, 0)
+    }
+
     #[test]
     fn evaluation() {
-        let mut lexer = crate::lexer::Lexer::new("a|b*");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "a", 0, 0));
-        assert!(eval(&inst, "b", 0, 0));
-        assert!(eval(&inst, "bb", 0, 0));
-        assert!(!eval(&inst, "c", 0, 0));
+        assert!(compile_and_eval("a|b*", "a"));
+        assert!(compile_and_eval("a|b*", "b"));
+        assert!(compile_and_eval("a|b*", "bb"));
+        assert!(!compile_and_eval("a|b*", "c"));
 
-        let mut lexer = crate::lexer::Lexer::new("a|b+");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "a", 0, 0));
-        assert!(eval(&inst, "b", 0, 0));
-        assert!(eval(&inst, "bb", 0, 0));
-        assert!(!eval(&inst, "c", 0, 0));
+        assert!(compile_and_eval("a|b+", "a"));
+        assert!(compile_and_eval("a|b+", "b"));
+        assert!(compile_and_eval("a|b+", "bb"));
+        assert!(!compile_and_eval("a|b+", "c"));
 
-        let mut lexer = crate::lexer::Lexer::new("a|b?");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "a", 0, 0));
-        assert!(eval(&inst, "b", 0, 0));
-        assert!(!eval(&inst, "bb", 0, 0));
-        assert!(!eval(&inst, "c", 0, 0));
+        assert!(compile_and_eval("a|b?", "a"));
+        assert!(compile_and_eval("a|b?", "b"));
+        assert!(!compile_and_eval("a|b?", "bb"));
+        assert!(!compile_and_eval("a|b?", "c"));
     }
 
     #[test]
     fn evaluation_empty() {
-        let mut lexer = crate::lexer::Lexer::new("a*");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "", 0, 0));
-        assert!(eval(&inst, "a", 0, 0));
-        assert!(eval(&inst, "aaa", 0, 0));
-        assert!(!eval(&inst, "b", 0, 0));
+        assert!(compile_and_eval("a*", ""));
+        assert!(compile_and_eval("a*", "a"));
+        assert!(compile_and_eval("a*", "aaa"));
+        assert!(!compile_and_eval("a*", "b"));
     }
 
     #[test]
     fn evaluation_complex() {
-        let mut lexer = crate::lexer::Lexer::new("ab(cd|)ef");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "abcdef", 0, 0));
-        assert!(eval(&inst, "abef", 0, 0));
-        assert!(!eval(&inst, "abc", 0, 0));
+        assert!(compile_and_eval("ab(cd|)ef", "abcdef"));
+        assert!(compile_and_eval("ab(cd|)ef", "abef"));
+        assert!(!compile_and_eval("ab(cd|)ef", "abc"));
     }
 
     #[test]
     fn evaluation_unicode() {
-        let mut lexer = crate::lexer::Lexer::new("正規表現(太郎|次郎)");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "正規表現太郎", 0, 0));
-        assert!(eval(&inst, "正規表現次郎", 0, 0));
-        assert!(!eval(&inst, "正規表現三郎", 0, 0));
+        assert!(compile_and_eval("正規表現(太郎|次郎)", "正規表現太郎"));
+        assert!(compile_and_eval("正規表現(太郎|次郎)", "正規表現次郎"));
+        assert!(!compile_and_eval("正規表現(太郎|次郎)", "正規表現三郎"));
     }
 
     #[test]
     fn evaluation_long_input() {
-        let mut lexer = crate::lexer::Lexer::new("a+b");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(!eval(&inst, &"a".repeat(10000), 0, 0));
-        assert!(eval(&inst, &format!("{}b", "a".repeat(10000)), 0, 0));
+        assert!(!compile_and_eval("a+b", &"a".repeat(10000)));
+        assert!(compile_and_eval("a+b", &format!("{}b", "a".repeat(10000))));
     }
 
     #[test]
     fn evaluation_empty_string() {
-        let mut lexer = crate::lexer::Lexer::new("a*");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "", 0, 0));
+        assert!(compile_and_eval("a*", ""));
     }
 
     #[test]
     fn evaluation_concat() {
-        let mut lexer = crate::lexer::Lexer::new("abc");
-        let mut parser = crate::parser::Parser::new(&mut lexer);
-        let ast = parser.parse().unwrap();
-        let mut compiler = crate::vm::compile::Compiler::new();
-        compiler.compile(ast).unwrap();
-        let inst = compiler.instructions().to_vec();
-        assert!(eval(&inst, "abc", 0, 0));
-        assert!(!eval(&inst, "ab", 0, 0));
-        assert!(!eval(&inst, "abcd", 0, 0));
-        assert!(!eval(&inst, "", 0, 0));
+        assert!(compile_and_eval("abc", "abc"));
+        assert!(!compile_and_eval("abc", "ab"));
+        assert!(!compile_and_eval("abc", "abcd"));
+        assert!(!compile_and_eval("abc", ""));
     }
 }

--- a/src/vm/instruction.rs
+++ b/src/vm/instruction.rs
@@ -1,7 +1,116 @@
+pub const OP_CHAR: u8 = 0;
+pub const OP_SPLIT: u8 = 1;
+pub const OP_JMP: u8 = 2;
+pub const OP_MATCH: u8 = 3;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Instruction {
-    Char(char),
-    Split(usize, usize),
-    Jmp(usize),
-    Match,
+pub struct Program {
+    opcodes: Vec<u8>,
+    op1: Vec<u32>,
+    op2: Vec<u32>,
+}
+
+impl Program {
+    pub fn len(&self) -> usize {
+        self.opcodes.len()
+    }
+
+    #[inline(always)]
+    pub fn opcode(&self, pc: usize) -> u8 {
+        *unsafe { self.opcodes.get_unchecked(pc) }
+    }
+
+    #[inline(always)]
+    pub fn operand1(&self, pc: usize) -> u32 {
+        *unsafe { self.op1.get_unchecked(pc) }
+    }
+
+    #[inline(always)]
+    pub fn operand2(&self, pc: usize) -> u32 {
+        *unsafe { self.op2.get_unchecked(pc) }
+    }
+
+    #[inline(always)]
+    pub fn char_literal(&self, pc: usize) -> char {
+        unsafe { char::from_u32_unchecked(self.operand1(pc)) }
+    }
+}
+
+pub struct ProgramBuilder {
+    opcodes: Vec<u8>,
+    op1: Vec<u32>,
+    op2: Vec<u32>,
+}
+
+impl ProgramBuilder {
+    pub fn new() -> Self {
+        ProgramBuilder {
+            opcodes: Vec::new(),
+            op1: Vec::new(),
+            op2: Vec::new(),
+        }
+    }
+
+    pub fn pc(&self) -> usize {
+        self.opcodes.len()
+    }
+
+    pub fn build(self) -> Program {
+        Program {
+            opcodes: self.opcodes,
+            op1: self.op1,
+            op2: self.op2,
+        }
+    }
+
+    fn emit(&mut self, opcode: u8, operand1: u32, operand2: u32) {
+        self.opcodes.push(opcode);
+        self.op1.push(operand1);
+        self.op2.push(operand2);
+    }
+
+    fn patch(&mut self, pc: usize, operand1: u32, operand2: u32) {
+        self.op1[pc] = operand1;
+        self.op2[pc] = operand2;
+    }
+
+    pub fn emit_char(&mut self, c: char) {
+        self.emit(OP_CHAR, c as u32, 0);
+    }
+
+    pub fn emit_split(&mut self, x: usize, y: usize) {
+        self.emit(OP_SPLIT, x as u32, y as u32);
+    }
+
+    pub fn emit_jmp(&mut self, target: usize) {
+        self.emit(OP_JMP, target as u32, 0);
+    }
+
+    pub fn emit_match(&mut self) {
+        self.emit(OP_MATCH, 0, 0);
+    }
+
+    pub fn reserve_split(&mut self) -> usize {
+        let pc = self.pc();
+        self.emit_split(0, 0);
+        pc
+    }
+
+    pub fn reserve_jmp(&mut self) -> usize {
+        let pc = self.pc();
+        self.emit_jmp(0);
+        pc
+    }
+
+    pub fn patch_split(&mut self, pc: usize, x: usize, y: usize) {
+        self.patch(pc, x as u32, y as u32);
+    }
+
+    pub fn patch_split_second(&mut self, pc: usize, y: usize) {
+        self.op2[pc] = y as u32;
+    }
+
+    pub fn patch_jmp(&mut self, pc: usize, target: usize) {
+        self.op1[pc] = target as u32;
+    }
 }


### PR DESCRIPTION
By representing VM instructions using Structure of Arrays, the instruction size is reduced, improving I-cache and data access performance in hot loops.

<img width="746" height="386" alt="" src="https://github.com/user-attachments/assets/33f10f0d-3994-4332-ab9e-ede983375ca0" />
