### PR TITLE
Add accelerated states to the DFA matcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mimalloc"
@@ -424,6 +424,7 @@ dependencies = [
  "bit-set",
  "criterion",
  "foldhash",
+ "memchr",
  "mimalloc",
  "regex",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 thiserror = "2.0.3"
 bit-set = "0.10.0"
 foldhash = "0.2.0"
+memchr = "2.8.2"
 mimalloc = "0.1.48"
 
 [dev-dependencies]

--- a/img/case-1.svg
+++ b/img/case-1.svg
@@ -4,28 +4,28 @@
 <style>text { font-family: ui-sans-serif, system-ui, sans-serif; fill: #1f2937; }.title { font-size: 18px; font-weight: 700; }.subtitle { font-size: 12px; fill: #4b5563; }.label { font-size: 13px; }.value { font-size: 12px; fill: #374151; }.axis { stroke: #9ca3af; stroke-width: 1; }.tick { stroke: #d1d5db; stroke-width: 1; }.tick-label { font-size: 11px; fill: #6b7280; }</style>
 <text class="title" x="170" y="28">case 1: Pattern `(p(erl|ython|hp)|ruby)`</text>
 <text class="subtitle" x="170" y="46">Lower is better (log scale)</text>
-<line class="axis" x1="170" y1="316" x2="690" y2="316"/>
+<line class="axis" x1="170" y1="316" x2="653" y2="316"/>
 <line class="axis" x1="170" y1="56" x2="170" y2="316"/>
 <line class="tick" x1="170.0" y1="56" x2="170.0" y2="316"/>
-<text class="tick-label" x="170.0" y="334" text-anchor="middle">19.0 ns</text>
-<line class="tick" x1="300.0" y1="56" x2="300.0" y2="316"/>
-<text class="tick-label" x="300.0" y="334" text-anchor="middle">71.6 ns</text>
-<line class="tick" x1="430.0" y1="56" x2="430.0" y2="316"/>
-<text class="tick-label" x="430.0" y="334" text-anchor="middle">269.6 ns</text>
-<line class="tick" x1="560.0" y1="56" x2="560.0" y2="316"/>
-<text class="tick-label" x="560.0" y="334" text-anchor="middle">1.02 µs</text>
-<line class="tick" x1="690.0" y1="56" x2="690.0" y2="316"/>
-<text class="tick-label" x="690.0" y="334" text-anchor="middle">3.82 µs</text>
+<text class="tick-label" x="170.0" y="334" text-anchor="middle">16.6 ns</text>
+<line class="tick" x1="290.8" y1="56" x2="290.8" y2="316"/>
+<text class="tick-label" x="290.8" y="334" text-anchor="middle">64.2 ns</text>
+<line class="tick" x1="411.5" y1="56" x2="411.5" y2="316"/>
+<text class="tick-label" x="411.5" y="334" text-anchor="middle">248.8 ns</text>
+<line class="tick" x1="532.2" y1="56" x2="532.2" y2="316"/>
+<text class="tick-label" x="532.2" y="334" text-anchor="middle">964.4 ns</text>
+<line class="tick" x1="653.0" y1="56" x2="653.0" y2="316"/>
+<text class="tick-label" x="653.0" y="334" text-anchor="middle">3.74 µs</text>
 <rect x="170.0" y="56.0" width="2.0" height="51.5" fill="#4c78a8" rx="4"/>
 <text class="label" x="160" y="85.75" text-anchor="end">rustegex DFA</text>
-<text class="value" x="180.0" y="85.75">19.0 ns</text>
-<rect x="170.0" y="125.5" width="85.3" height="51.5" fill="#59a14f" rx="4"/>
+<text class="value" x="180.0" y="85.75">16.6 ns</text>
+<rect x="170.0" y="125.5" width="71.8" height="51.5" fill="#59a14f" rx="4"/>
 <text class="label" x="160" y="155.25" text-anchor="end">rustegex VM</text>
-<text class="value" x="263.3" y="155.25">45.4 ns</text>
-<rect x="170.0" y="195.0" width="520.0" height="51.5" fill="#f28e2b" rx="4"/>
+<text class="value" x="249.8" y="155.25">37.1 ns</text>
+<rect x="170.0" y="195.0" width="483.0" height="51.5" fill="#f28e2b" rx="4"/>
 <text class="label" x="160" y="224.75" text-anchor="end">rustegex Derivative</text>
-<text class="value" x="698.0" y="224.75">3.82 µs</text>
-<rect x="170.0" y="264.5" width="154.7" height="51.5" fill="#b279a2" rx="4"/>
+<text class="value" x="661.0" y="224.75">3.74 µs</text>
+<rect x="170.0" y="264.5" width="150.2" height="51.5" fill="#b279a2" rx="4"/>
 <text class="label" x="160" y="294.25" text-anchor="end">regex crate</text>
-<text class="value" x="332.7" y="294.25">92.1 ns</text>
+<text class="value" x="328.2" y="294.25">89.3 ns</text>
 </svg>

--- a/img/case-2.svg
+++ b/img/case-2.svg
@@ -4,28 +4,28 @@
 <style>text { font-family: ui-sans-serif, system-ui, sans-serif; fill: #1f2937; }.title { font-size: 18px; font-weight: 700; }.subtitle { font-size: 12px; fill: #4b5563; }.label { font-size: 13px; }.value { font-size: 12px; fill: #374151; }.axis { stroke: #9ca3af; stroke-width: 1; }.tick { stroke: #d1d5db; stroke-width: 1; }.tick-label { font-size: 11px; fill: #6b7280; }</style>
 <text class="title" x="170" y="28">case 2: Pattern `ab(cd|)ef|g*|h+`</text>
 <text class="subtitle" x="170" y="46">Lower is better (log scale)</text>
-<line class="axis" x1="170" y1="316" x2="690" y2="316"/>
+<line class="axis" x1="170" y1="316" x2="653" y2="316"/>
 <line class="axis" x1="170" y1="56" x2="170" y2="316"/>
 <line class="tick" x1="170.0" y1="56" x2="170.0" y2="316"/>
-<text class="tick-label" x="170.0" y="334" text-anchor="middle">34.6 ns</text>
-<line class="tick" x1="300.0" y1="56" x2="300.0" y2="316"/>
-<text class="tick-label" x="300.0" y="334" text-anchor="middle">119.4 ns</text>
-<line class="tick" x1="430.0" y1="56" x2="430.0" y2="316"/>
-<text class="tick-label" x="430.0" y="334" text-anchor="middle">411.8 ns</text>
-<line class="tick" x1="560.0" y1="56" x2="560.0" y2="316"/>
-<text class="tick-label" x="560.0" y="334" text-anchor="middle">1.42 µs</text>
-<line class="tick" x1="690.0" y1="56" x2="690.0" y2="316"/>
-<text class="tick-label" x="690.0" y="334" text-anchor="middle">4.90 µs</text>
+<text class="tick-label" x="170.0" y="334" text-anchor="middle">32.9 ns</text>
+<line class="tick" x1="290.8" y1="56" x2="290.8" y2="316"/>
+<text class="tick-label" x="290.8" y="334" text-anchor="middle">114.6 ns</text>
+<line class="tick" x1="411.5" y1="56" x2="411.5" y2="316"/>
+<text class="tick-label" x="411.5" y="334" text-anchor="middle">399.5 ns</text>
+<line class="tick" x1="532.2" y1="56" x2="532.2" y2="316"/>
+<text class="tick-label" x="532.2" y="334" text-anchor="middle">1.39 µs</text>
+<line class="tick" x1="653.0" y1="56" x2="653.0" y2="316"/>
+<text class="tick-label" x="653.0" y="334" text-anchor="middle">4.85 µs</text>
 <rect x="170.0" y="56.0" width="2.0" height="51.5" fill="#4c78a8" rx="4"/>
 <text class="label" x="160" y="85.75" text-anchor="end">rustegex DFA</text>
-<text class="value" x="180.0" y="85.75">34.6 ns</text>
-<rect x="170.0" y="125.5" width="127.0" height="51.5" fill="#59a14f" rx="4"/>
+<text class="value" x="180.0" y="85.75">32.9 ns</text>
+<rect x="170.0" y="125.5" width="100.5" height="51.5" fill="#59a14f" rx="4"/>
 <text class="label" x="160" y="155.25" text-anchor="end">rustegex VM</text>
-<text class="value" x="305.0" y="155.25">116.1 ns</text>
-<rect x="170.0" y="195.0" width="520.0" height="51.5" fill="#f28e2b" rx="4"/>
+<text class="value" x="278.5" y="155.25">93.0 ns</text>
+<rect x="170.0" y="195.0" width="483.0" height="51.5" fill="#f28e2b" rx="4"/>
 <text class="label" x="160" y="224.75" text-anchor="end">rustegex Derivative</text>
-<text class="value" x="698.0" y="224.75">4.90 µs</text>
-<rect x="170.0" y="264.5" width="83.7" height="51.5" fill="#b279a2" rx="4"/>
+<text class="value" x="661.0" y="224.75">4.85 µs</text>
+<rect x="170.0" y="264.5" width="92.6" height="51.5" fill="#b279a2" rx="4"/>
 <text class="label" x="160" y="294.25" text-anchor="end">regex crate</text>
-<text class="value" x="261.7" y="294.25">76.8 ns</text>
+<text class="value" x="270.6" y="294.25">85.7 ns</text>
 </svg>

--- a/img/case-long.svg
+++ b/img/case-long.svg
@@ -4,28 +4,28 @@
 <style>text { font-family: ui-sans-serif, system-ui, sans-serif; fill: #1f2937; }.title { font-size: 18px; font-weight: 700; }.subtitle { font-size: 12px; fill: #4b5563; }.label { font-size: 13px; }.value { font-size: 12px; fill: #374151; }.axis { stroke: #9ca3af; stroke-width: 1; }.tick { stroke: #d1d5db; stroke-width: 1; }.tick-label { font-size: 11px; fill: #6b7280; }</style>
 <text class="title" x="170" y="28">case long: Pattern `a+b`, input is 1,000,000 a characters</text>
 <text class="subtitle" x="170" y="46">Lower is better (log scale)</text>
-<line class="axis" x1="170" y1="316" x2="690" y2="316"/>
+<line class="axis" x1="170" y1="316" x2="639" y2="316"/>
 <line class="axis" x1="170" y1="56" x2="170" y2="316"/>
 <line class="tick" x1="170.0" y1="56" x2="170.0" y2="316"/>
-<text class="tick-label" x="170.0" y="334" text-anchor="middle">1.21 ms</text>
-<line class="tick" x1="300.0" y1="56" x2="300.0" y2="316"/>
-<text class="tick-label" x="300.0" y="334" text-anchor="middle">3.34 ms</text>
-<line class="tick" x1="430.0" y1="56" x2="430.0" y2="316"/>
-<text class="tick-label" x="430.0" y="334" text-anchor="middle">9.19 ms</text>
-<line class="tick" x1="560.0" y1="56" x2="560.0" y2="316"/>
-<text class="tick-label" x="560.0" y="334" text-anchor="middle">25.29 ms</text>
-<line class="tick" x1="690.0" y1="56" x2="690.0" y2="316"/>
-<text class="tick-label" x="690.0" y="334" text-anchor="middle">69.60 ms</text>
-<rect x="170.0" y="56.0" width="30.3" height="51.5" fill="#4c78a8" rx="4"/>
+<text class="tick-label" x="170.0" y="334" text-anchor="middle">219.76 µs</text>
+<line class="tick" x1="287.3" y1="56" x2="287.3" y2="316"/>
+<text class="tick-label" x="287.3" y="334" text-anchor="middle">946.71 µs</text>
+<line class="tick" x1="404.5" y1="56" x2="404.5" y2="316"/>
+<text class="tick-label" x="404.5" y="334" text-anchor="middle">4.08 ms</text>
+<line class="tick" x1="521.8" y1="56" x2="521.8" y2="316"/>
+<text class="tick-label" x="521.8" y="334" text-anchor="middle">17.57 ms</text>
+<line class="tick" x1="639.0" y1="56" x2="639.0" y2="316"/>
+<text class="tick-label" x="639.0" y="334" text-anchor="middle">75.69 ms</text>
+<rect x="170.0" y="56.0" width="2.0" height="51.5" fill="#4c78a8" rx="4"/>
 <text class="label" x="160" y="85.75" text-anchor="end">rustegex DFA</text>
-<text class="value" x="208.3" y="85.75">1.54 ms</text>
-<rect x="170.0" y="125.5" width="97.6" height="51.5" fill="#59a14f" rx="4"/>
+<text class="value" x="180.0" y="85.75">219.76 µs</text>
+<rect x="170.0" y="125.5" width="197.7" height="51.5" fill="#59a14f" rx="4"/>
 <text class="label" x="160" y="155.25" text-anchor="end">rustegex VM</text>
-<text class="value" x="275.6" y="155.25">2.60 ms</text>
-<rect x="170.0" y="195.0" width="520.0" height="51.5" fill="#f28e2b" rx="4"/>
+<text class="value" x="375.7" y="155.25">2.58 ms</text>
+<rect x="170.0" y="195.0" width="469.0" height="51.5" fill="#f28e2b" rx="4"/>
 <text class="label" x="160" y="224.75" text-anchor="end">rustegex Derivative</text>
-<text class="value" x="698.0" y="224.75">69.60 ms</text>
-<rect x="170.0" y="264.5" width="2.0" height="51.5" fill="#b279a2" rx="4"/>
+<text class="value" x="647.0" y="224.75">75.69 ms</text>
+<rect x="170.0" y="264.5" width="139.8" height="51.5" fill="#b279a2" rx="4"/>
 <text class="label" x="160" y="294.25" text-anchor="end">regex crate</text>
-<text class="value" x="180.0" y="294.25">1.21 ms</text>
+<text class="value" x="317.8" y="294.25">1.25 ms</text>
 </svg>

--- a/src/automaton/dfa.rs
+++ b/src/automaton/dfa.rs
@@ -2,6 +2,34 @@ use foldhash::HashMapExt as _;
 
 pub type DfaStateID = u64;
 const DEAD: DfaStateID = DfaStateID::MAX;
+const ACCEL_MIN_REMAINING: usize = 32;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct Accel {
+    loop_byte: Option<u8>,
+    needles: [u8; 3],
+    needle_len: u8,
+}
+
+impl Accel {
+    fn is_enabled(self) -> bool {
+        self.loop_byte.is_some() || self.needle_len > 0
+    }
+
+    fn memchr_fwd(&self, haystack: &[u8], at: usize) -> Option<usize> {
+        if self.needle_len == 0 {
+            return None;
+        }
+        let slice = &haystack[at..];
+        let offset = match self.needle_len {
+            1 => memchr::memchr(self.needles[0], slice)?,
+            2 => memchr::memchr2(self.needles[0], self.needles[1], slice)?,
+            3 => memchr::memchr3(self.needles[0], self.needles[1], self.needles[2], slice)?,
+            _ => return None,
+        };
+        Some(at + offset)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Dfa {
@@ -10,6 +38,7 @@ pub struct Dfa {
     state_count: usize,
     ascii_table: Vec<DfaStateID>,
     unicode_table: Vec<foldhash::HashMap<char, DfaStateID>>,
+    accels: Vec<Accel>,
 }
 
 impl Dfa {
@@ -20,6 +49,7 @@ impl Dfa {
             state_count: 0,
             ascii_table: Vec::new(),
             unicode_table: Vec::new(),
+            accels: Vec::new(),
         }
     }
 
@@ -30,6 +60,12 @@ impl Dfa {
     #[cfg(test)]
     pub fn accepts_contains(&self, state: DfaStateID) -> bool {
         self.accepts.contains(state as usize)
+    }
+
+    #[cfg(test)]
+    pub fn accel(&self, state: DfaStateID) -> (Option<u8>, u8, [u8; 3]) {
+        let accel = self.accels[state as usize];
+        (accel.loop_byte, accel.needle_len, accel.needles)
     }
 
     #[cfg(test)]
@@ -124,6 +160,10 @@ impl Dfa {
             }
         }
 
+        dfa.accels = (0..state_count)
+            .map(|state| build_accel(state, &dfa.ascii_table))
+            .collect();
+
         dfa
     }
 
@@ -131,16 +171,15 @@ impl Dfa {
         let mut state = self.start();
 
         if input.is_ascii() {
-            let table = &self.ascii_table;
-            for &byte in input.as_bytes() {
-                // SAFETY: `state < state_count` (invariant) and `byte < 128` (guaranteed by `input.is_ascii()`),
-                // so `state as usize * 128 + byte as usize < state_count * 128 == table.len()`.
-                let next = *unsafe { table.get_unchecked(state as usize * 128 + byte as usize) };
-                if next == DEAD {
-                    return false;
-                }
-                state = next;
-            }
+            let bytes = input.as_bytes();
+            state = match if bytes.len() < ACCEL_MIN_REMAINING {
+                self.step_ascii(bytes, state)
+            } else {
+                self.step_ascii_accel(bytes, state)
+            } {
+                Ok(state) => state,
+                Err(()) => return false,
+            };
         } else {
             let table = &self.ascii_table;
             let unicode = &self.unicode_table;
@@ -161,11 +200,129 @@ impl Dfa {
 
         self.accepts.contains(state as usize)
     }
+
+    #[inline]
+    fn step_ascii(&self, bytes: &[u8], mut state: DfaStateID) -> Result<DfaStateID, ()> {
+        let table = &self.ascii_table;
+        for &byte in bytes {
+            let next = *unsafe { table.get_unchecked(state as usize * 128 + byte as usize) };
+            if next == DEAD {
+                return Err(());
+            }
+            state = next;
+        }
+        Ok(state)
+    }
+
+    #[inline]
+    fn step_ascii_accel(&self, bytes: &[u8], mut state: DfaStateID) -> Result<DfaStateID, ()> {
+        let table = &self.ascii_table;
+        let mut at = 0usize;
+        let len = bytes.len();
+
+        while at < len {
+            let remaining = len - at;
+            if remaining >= ACCEL_MIN_REMAINING {
+                let accel = self.accels[state as usize];
+                if accel.is_enabled() {
+                    if let Some(loop_byte) = accel.loop_byte {
+                        let start = at;
+                        while at < len && bytes[at] == loop_byte {
+                            at += 1;
+                        }
+                        if at >= len {
+                            break;
+                        }
+                        if at > start {
+                            continue;
+                        }
+                    } else if let Some(hit) = accel.memchr_fwd(bytes, at) {
+                        at = hit;
+                        if at >= len {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            let byte = bytes[at];
+            let next = *unsafe { table.get_unchecked(state as usize * 128 + byte as usize) };
+            if next == DEAD {
+                return Err(());
+            }
+            state = next;
+            at += 1;
+        }
+
+        Ok(state)
+    }
+}
+
+fn build_accel(state: usize, table: &[DfaStateID]) -> Accel {
+    let base = state * 128;
+    let self_id = state as DfaStateID;
+
+    let mut loop_bytes = Vec::new();
+    let mut exit_bytes: Vec<u8> = Vec::new();
+
+    for byte in 0u8..128 {
+        let next = table[base + byte as usize];
+        if next == self_id {
+            loop_bytes.push(byte);
+        } else if next != DEAD {
+            exit_bytes.push(byte);
+        }
+    }
+
+    let loop_byte = if loop_bytes.len() == 1 {
+        Some(loop_bytes[0])
+    } else {
+        None
+    };
+
+    let mut unique_exits = Vec::new();
+    for byte in exit_bytes {
+        let next = table[base + byte as usize];
+        if !unique_exits.iter().any(|&(_, id)| id == next) {
+            unique_exits.push((byte, next));
+        }
+    }
+
+    if unique_exits.len() > 3 {
+        return Accel::default();
+    }
+
+    if loop_byte.is_none() && unique_exits.is_empty() {
+        return Accel::default();
+    }
+
+    let mut needles = [0u8; 3];
+    for (i, &(byte, _)) in unique_exits.iter().enumerate() {
+        needles[i] = byte;
+    }
+
+    Accel {
+        loop_byte,
+        needles,
+        needle_len: unique_exits.len() as u8,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn dfa_from_pattern(pattern: &str) -> Dfa {
+        let mut lexer = crate::lexer::Lexer::new(pattern);
+        let mut parser = crate::parser::Parser::new(&mut lexer);
+        let ast = parser.parse().unwrap();
+        let nfa = crate::automaton::nfa::Nfa::new_from_node(
+            ast,
+            &mut crate::automaton::nfa::NfaState::new(),
+        )
+        .unwrap();
+        Dfa::from_nfa(&nfa)
+    }
 
     #[test]
     fn test_dfa_from_nfa() {
@@ -236,5 +393,38 @@ mod tests {
             .collect();
 
         assert_eq!(b_loops.len(), 1);
+    }
+
+    #[test]
+    fn accel_a_plus_b() {
+        let dfa = dfa_from_pattern("a+b");
+        let mut saw_loop = false;
+        for state in 0..dfa.state_count {
+            let (loop_byte, needle_len, needles) = dfa.accel(state as DfaStateID);
+            if loop_byte == Some(b'a') {
+                saw_loop = true;
+                assert_eq!(needle_len, 1);
+                assert_eq!(needles[0], b'b');
+            }
+        }
+        assert!(saw_loop);
+        assert!(!dfa.is_match(&"a".repeat(1000)));
+        assert!(dfa.is_match(&format!("{}b", "a".repeat(1000))));
+        assert!(!dfa.is_match(&format!("{}c", "a".repeat(10))));
+    }
+
+    #[test]
+    fn accel_star_b() {
+        let dfa = dfa_from_pattern("b*");
+        let mut saw_loop = false;
+        for state in 0..dfa.state_count {
+            let (loop_byte, needle_len, _) = dfa.accel(state as DfaStateID);
+            if loop_byte == Some(b'b') && needle_len == 0 {
+                saw_loop = true;
+            }
+        }
+        assert!(saw_loop);
+        assert!(dfa.is_match(""));
+        assert!(dfa.is_match(&"b".repeat(1000)));
     }
 }


### PR DESCRIPTION
Precompute per-state acceleration metadata at DFA build time. States with a single-byte self-loop bulk-skip repeated bytes; states with up to three non-dead exits use memchr to jump forward. This achieves faster matching for long inputs.

<img width="720" height="360" alt="case-long" src="https://github.com/user-attachments/assets/775113ff-0ef0-4b50-9798-aab394ced7e9" />
